### PR TITLE
Reading pages, sorting posts correctly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+## [Untagged]
+
+### Features
+- Display tags page navigation and filtering
+- Improve page title display
+- Add hero images to blog posts and pages
+- Enhance cards and SEO in /pages section
+- Update post configuration for better population
+- Add more posts to /blog with date sorting
+- Display links in homepage
+
+### Fixed
+- Fix search page functionality
+- Fix bug in Strapi local setup
+- Remove unnecessary Dockerfile
+
 ## v4.3.1 (2024-07-27)
 
 ### Fix
@@ -74,7 +91,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Others
 
-* adds blog post for how to add a social icon ([#221](https://github.com/satnaing/astro-paper/issues/221)) 
+* adds blog post for how to add a social icon ([#221](https://github.com/satnaing/astro-paper/issues/221))
 * updates the hook post with a smarter updateHook ([#222](https://github.com/satnaing/astro-paper/issues/222))
 * update breadcrumbs delimiter to "»" ([#213](https://github.com/satnaing/astro-paper/issues/213))
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,35 +1,79 @@
-import { slugifyStr } from "@utils/slugify";
-import Datetime from "./Datetime";
-import type { CollectionEntry } from "astro:content";
+interface SEOImage {
+  url: string;
+  alternativeText: string | null;
+  width: number;
+  height: number;
+}
+
+interface SEO {
+  metaTitle: string;
+  metaDescription: string;
+  socialImage?: SEOImage;
+}
 
 export interface Props {
   href?: string;
-  frontmatter: CollectionEntry<"blog">["data"];
+  author?: string;
+  tags: string[];
+  frontmatter: {
+    title: string;
+    pubDatetime: Date;
+    modDatetime: Date;
+    description: string;
+    metaDescription: string;
+    SEO?: SEO;
+  };
   secHeading?: boolean;
 }
 
 export default function Card({ href, frontmatter, secHeading = true }: Props) {
-  const { title, pubDatetime, modDatetime, description } = frontmatter;
-
-  const headerProps = {
-    style: { viewTransitionName: slugifyStr(title) },
-    className: "text-lg font-medium decoration-dashed hover:underline",
-  };
+  const { title, pubDatetime, description, SEO } = frontmatter;
+  const imageUrl = SEO?.socialImage?.url;
 
   return (
-    <li className="my-6">
-      <a
-        href={href}
-        className="inline-block text-lg font-medium text-skin-accent decoration-dashed underline-offset-4 focus-visible:no-underline focus-visible:underline-offset-0"
-      >
-        {secHeading ? (
-          <h2 {...headerProps}>{title}</h2>
-        ) : (
-          <h3 {...headerProps}>{title}</h3>
-        )}
-      </a>
-      <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} />
-      <p>{description}</p>
+    <li className="mb-8">
+      <article className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300">
+        <a href={href} className="block group">
+          {imageUrl && (
+            <div className="relative aspect-video overflow-hidden">
+              <img
+                src={imageUrl}
+                alt={SEO?.socialImage?.alternativeText || title}
+                className="w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-500"
+                width={SEO?.socialImage?.width}
+                height={SEO?.socialImage?.height}
+                loading="lazy"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+            </div>
+          )}
+          <div className="p-6">
+            {secHeading ? (
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 group-hover:text-accent-500 transition-colors">
+                {title}
+              </h2>
+            ) : (
+              <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 group-hover:text-accent-500 transition-colors">
+                {title}
+              </h3>
+            )}
+            <div className="flex items-center gap-2 mb-3">
+              <span className="px-3 py-1 text-xs font-medium bg-accent-100 text-accent-700 dark:bg-accent-900/30 dark:text-accent-300 rounded-full">
+                {new Date(pubDatetime).toLocaleDateString()}
+              </span>
+            </div>
+            <p className="text-gray-600 dark:text-gray-300 line-clamp-3 mb-4">
+              {description}
+            </p>
+            <div className="flex items-center text-accent-500 dark:text-accent-400 font-medium">
+              Read more
+              <svg className="w-4 h-4 ml-2 transform group-hover:translate-x-1 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5-5 5M6 7l5 5-5 5" />
+              </svg>
+            </div>
+          </div>
+        </a>
+      </article>
     </li>
   );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,15 +1,5 @@
-interface SEOImage {
-  url: string;
-  alternativeText: string | null;
-  width: number;
-  height: number;
-}
-
-interface SEO {
-  metaTitle: string;
-  metaDescription: string;
-  socialImage?: SEOImage;
-}
+import Tag from './Tag.astro';
+import type { SEO } from '../interfaces/Article';
 
 export interface Props {
   href?: string;
@@ -20,13 +10,13 @@ export interface Props {
     pubDatetime: Date;
     modDatetime: Date;
     description: string;
-    metaDescription: string;
     SEO?: SEO;
+    author?: string;
   };
   secHeading?: boolean;
 }
 
-export default function Card({ href, frontmatter, secHeading = true }: Props) {
+export default function Card({ href, frontmatter, tags, secHeading = true }: Props) {
   const { title, pubDatetime, description, SEO } = frontmatter;
   const imageUrl = SEO?.socialImage?.url;
 
@@ -71,6 +61,12 @@ export default function Card({ href, frontmatter, secHeading = true }: Props) {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5-5 5M6 7l5 5-5 5" />
               </svg>
             </div>
+            <ul>
+              {tags?.map((tag) => {
+                if (!tag) return null;
+                <Tag tag={tag || 'x'} size="sm" />
+              })}
+            </ul>
           </div>
         </a>
       </article>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const currentYear = new Date().getFullYear();
 
 export interface Props {
   noMarginTop?: boolean;
-  activeNav: string;
+  activeNav?: string;
 }
 
 const { activeNav, noMarginTop = false } = Astro.props;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,19 +6,26 @@ const currentYear = new Date().getFullYear();
 
 export interface Props {
   noMarginTop?: boolean;
+  activeNav: string;
 }
 
-const { noMarginTop = false } = Astro.props;
+const { activeNav, noMarginTop = false } = Astro.props;
 ---
 
 <footer class={`${noMarginTop ? "" : "mt-auto"}`}>
   <Hr noPadding />
-  <div class="footer-wrapper">
+  <div class="footer-wrapper mb-10">
     <Socials centered />
     <div class="copyright-wrapper">
       <span>Copyleft &#169; {currentYear}</span>
       <span class="separator">&nbsp;|&nbsp;</span>
       <span>Some rights reserved.</span>
+      &nbsp;|&nbsp;
+      <span>
+        <a href="/pages/" class={activeNav === "pages" ? "active" : ""}>
+          Pages
+        </a>
+      </span>
     </div>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ import LinkButton from "./LinkButton.astro";
 import type Store from "../interfaces/Store";
 
 export interface Props {
-  activeNav?: "posts" | "tags" | "about" | "search";
+  activeNav?: "posts" | "tags" | "about" | "search" | "pages";
   store?: Store;
 }
 

--- a/src/components/HeroImage.astro
+++ b/src/components/HeroImage.astro
@@ -1,0 +1,29 @@
+---
+interface Props {
+  image: {
+    url: string;
+    alternativeText?: string | null;
+    width?: number;
+    height?: number;
+  };
+  title: string;
+}
+
+const { image, title } = Astro.props;
+---
+
+{
+  image && (
+    <div class="relative mb-6 aspect-video w-full overflow-hidden rounded-xl">
+      <img
+        src={image.url}
+        alt={image.alternativeText || title}
+        width={image.width}
+        height={image.height}
+        class="h-full w-full object-cover"
+        loading="eager"
+      />
+      <div class="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent" />
+    </div>
+  )
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Fuse from "fuse.js";
 import { useEffect, useRef, useState, useMemo } from "react";
 import Card from "@components/Card";
@@ -113,13 +114,14 @@ export default function SearchBar({ searchList }: Props) {
           searchResults.map(({ item, refIndex }) => (
             <Card
               href={item.slug}
+              tags={item?.data?.Tags?.map((tag: { Label: string }) => tag.Label) || []}
               frontmatter={{
                 author: "x",
-                tags: item.data.Tags.map(tag => tag.Label),
                 title: item.data.Title,
                 pubDatetime: new Date(item.data.createdAt),
                 modDatetime: new Date(item.data.updatedAt),
                 description: item.data.SEO?.metaDescription || "",
+                SEO: item.data?.SEO,
               }}
               key={`${refIndex}-${item.slug}`}
             />

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const SITE: Site = {
   ogImage: "astropaper-og.jpg",
   lightAndDarkMode: true,
   postPerIndex: 4,
-  postPerPage: 3,
+  postPerPage: 8,
   scheduledPostMargin: 15 * 60 * 1000, // 15 minutes
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,12 +6,12 @@ export const markketplace = {
 };
 
 export const SITE: Site = {
-  website: "https://morirsoniando.com/",
+  website: "https://markket.place/",
   author: "Club Calima",
   profile: "https://caliman.org/",
   desc: "A minimal, responsive and SEO-friendly Markketplace theme.",
   title: "Morir Soñando",
-  ogImage: "astropaper-og.jpg",
+  ogImage: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/3852868ed9aad1e45e4ee4992fe43177.png",
   lightAndDarkMode: true,
   postPerIndex: 4,
   postPerPage: 8,
@@ -53,12 +53,6 @@ export const SOCIALS: SocialObjects = [
   //   name: "Mail",
   //   href: "mailto:yourmail@gmail.com",
   //   linkTitle: `Send an email to ${SITE.title}`,
-  //   active: false,
-  // },
-  // {
-  //   name: "Twitter",
-  //   href: "https://github.com/satnaing/astro-paper",
-  //   linkTitle: `${SITE.title} on Twitter`,
   //   active: false,
   // },
   // {
@@ -143,6 +137,11 @@ export const SOCIALS: SocialObjects = [
   //   name: "Mastodon",
   //   href: "https://github.com/satnaing/astro-paper",
   //   linkTitle: `${SITE.title} on Mastodon`,
+  //   active: false,
+  // },
+  //   name: "BlueSky",
+  //   href: "https://bsky.app/profile/markketplace.bsky.social",
+  //   linkTitle: `${SITE.title} on BlueSKy`,
   //   active: false,
   // },
 ];

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,7 +5,11 @@ import { strapiLoader } from "../lib/strapi-loader";
 
 
 const pages = defineCollection({
-  loader: strapiLoader({ contentType: "page", filter: `filters[store][slug][$eq]=${markketplace.STORE_SLUG}` }),
+  loader: strapiLoader({
+    contentType: "page", filter: `filters[store][slug][$eq]=${markketplace.STORE_SLUG}`,
+    populate: 'SEO.socialImage,store'
+  }),
+
 });
 
 const stores = defineCollection({

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,9 +3,6 @@ import { defineCollection } from "astro:content";
 
 import { strapiLoader } from "../lib/strapi-loader";
 
-const posts = defineCollection({
-  loader: strapiLoader({ contentType: "article", filter: `filters[store][slug][$eq]=${markketplace.STORE_SLUG}` }),
-});
 
 const pages = defineCollection({
   loader: strapiLoader({ contentType: "page", filter: `filters[store][slug][$eq]=${markketplace.STORE_SLUG}` }),
@@ -13,6 +10,13 @@ const pages = defineCollection({
 
 const stores = defineCollection({
   loader: strapiLoader({ contentType: "store", filter: `filters[slug][$eq]=${markketplace.STORE_SLUG}` }),
+});
+
+const posts = defineCollection({
+  loader: strapiLoader({
+    contentType: "article", filter: `filters[store][slug][$eq]=${markketplace.STORE_SLUG}`,
+    populate: 'SEO.socialImage,Tags,store'
+  }),
 });
 
 export const collections = { posts, pages, stores };

--- a/src/interfaces/Article.ts
+++ b/src/interfaces/Article.ts
@@ -1,0 +1,17 @@
+export interface Tag {
+  Label: string;
+  Color: string;
+}
+
+export interface SEOImage {
+  url: string;
+  alternativeText: string | null;
+  width: number;
+  height: number;
+}
+
+export interface SEO {
+  metaTitle: string;
+  metaDescription: string;
+  socialImage?: SEOImage;
+}

--- a/src/interfaces/Page.ts
+++ b/src/interfaces/Page.ts
@@ -29,6 +29,7 @@ export default interface Page {
   SEO: {
     metaDescription: string,
     metaTitle: string,
+    socialImage: {},
   },
   createdAt: string;
   updatedAt: string;

--- a/src/interfaces/Store.ts
+++ b/src/interfaces/Store.ts
@@ -8,6 +8,7 @@ export default interface Store {
   slug: string;
   products: { data: [] };
   URLS: { Label: string, URL: string, }[];
+  SEO: {};
   Logo: {
     id: string,
     url: string,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,8 @@
 ---
-import { LOCALE, SITE } from "@config";
+import { LOCALE, SITE, markketplace } from "@config";
 import "@styles/base.css";
 import { ViewTransitions } from "astro:transitions";
+import { getCollection } from "astro:content";
 
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
@@ -21,7 +22,7 @@ const {
   title = SITE.title,
   author = SITE.author,
   profile = SITE.profile,
-  description = SITE.desc,
+  description = Astro.props.description ?? SITE.desc,
   ogImage = SITE.ogImage,
   canonicalURL = new URL(Astro.url.pathname, Astro.site).href,
   pubDatetime,
@@ -49,6 +50,11 @@ const structuredData = {
     },
   ],
 };
+
+const stores = await getCollection("stores");
+const store = stores.find(
+  store => store.data.slug == markketplace.STORE_SLUG
+)?.data;
 ---
 
 <!doctype html>
@@ -64,17 +70,26 @@ const structuredData = {
     <meta name="generator" content={Astro.generator} />
 
     <!-- General Meta Tags -->
-    <title>{title}</title>
-    <meta name="title" content={title} />
-    <meta name="description" content={description} />
+    <title>{store?.title || title}</title>
+    <meta name="title" content={store?.title || title} />
+    <meta name="description" content={store?.Description || description} />
     <meta name="author" content={author} />
     <link rel="sitemap" href="/sitemap-index.xml" />
 
     <!-- Open Graph / Facebook -->
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={canonicalURL} />
-    <meta property="og:image" content={socialImageURL} />
+    <meta
+      property="og:title"
+      content={store?.SEO?.metaTitle || store?.title || title}
+    />
+    <meta
+      property="og:description"
+      content={store?.SEO?.metaDescription || store?.Description || description}
+    />
+    <meta property="og:url" content={store?.SEO?.metaUrl || canonicalURL} />
+    <meta
+      property="og:image"
+      content={store?.SEO?.socialImage?.url || socialImageURL}
+    />
 
     <!-- Article Published/Modified time -->
     {

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -9,6 +9,8 @@ import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
 import { SITE } from "@config";
 
+import HeroImage from "@components/HeroImage.astro";
+
 import { BlocksRenderer } from "@strapi/blocks-react-renderer";
 import { getCollection } from "astro:content";
 import type Store from "../interfaces/Store";
@@ -30,7 +32,8 @@ const {
   canonicalURL,
   pubDatetime,
   modDatetime,
-  tags,
+  Tags,
+  SEO,
 } = post.data;
 
 const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
@@ -68,6 +71,7 @@ const layoutProps = {
     </button>
   </div>
   <main id="main-content">
+    <HeroImage image={SEO?.socialImage} title={Title} />
     <h1 transition:name={slugifyStr(Title)} class="post-title">{Title}</h1>
     <Datetime
       pubDatetime={post.data.createdAt}
@@ -80,7 +84,7 @@ const layoutProps = {
     </article>
 
     <ul class="my-8">
-      {post.data.Tags.map(tag => <Tag tag={slugifyStr(tag.Label)} />)}
+      {Tags.map(tag => <Tag tag={slugifyStr(tag.Label)} />)}
     </ul>
 
     <div

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -32,9 +32,9 @@ const { currentPage, totalPages, paginatedPosts } = Astro.props;
         paginatedPosts.map(({ id, data }) => (
           <Card
             href={`/posts/${id}-${slugifyStr(data.Title)}/`}
+            tags={data.Tags.map((tag: { Label: string }) => tag.Label)}
             frontmatter={{
               author: "x",
-              tags: ["x"],
               title: data.Title || "---",
               pubDatetime: new Date(data.createdAt),
               modDatetime: new Date(data.updatedAt),
@@ -54,5 +54,5 @@ const { currentPage, totalPages, paginatedPosts } = Astro.props;
     nextUrl={`/posts/${currentPage + 1}/`}
   />
 
-  <Footer noMarginTop={totalPages > 1} />
+  <Footer noMarginTop={totalPages > 1} activeNav="x" />
 </Layout>

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -39,6 +39,7 @@ const { currentPage, totalPages, paginatedPosts } = Astro.props;
               pubDatetime: new Date(data.createdAt),
               modDatetime: new Date(data.updatedAt),
               description: data.SEO?.metaDescription || "",
+              SEO: { ...data.SEO },
             }}
           />
         ))

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -6,13 +6,15 @@ import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
 import Card from "@components/Card";
 import Pagination from "@components/Pagination.astro";
-import { SITE } from "@config";
+import { SITE, markketplace } from "@config";
 import { getCollection } from "astro:content";
 import type Store from "../interfaces/Store";
 import { slugifyStr } from "@utils/slugify";
 
 const stores = await getCollection("stores");
-const store = stores?.[0]?.data as unknown as Store;
+const store = stores?.find(
+  (store: { data: Store }) => store.data.slug === markketplace.STORE_SLUG
+)?.data;
 
 export interface Props {
   currentPage: number;
@@ -22,7 +24,13 @@ export interface Props {
   tagName: string;
 }
 
-const { currentPage, totalPages, paginatedPosts, tag, tagName } = Astro.props;
+const {
+  currentPage,
+  totalPages,
+  paginatedPosts,
+  tag = "all",
+  tagName,
+} = Astro.props;
 ---
 
 <Layout title={`Tag: ${tagName} | ${SITE.title}`}>
@@ -38,9 +46,9 @@ const { currentPage, totalPages, paginatedPosts, tag, tagName } = Astro.props;
         paginatedPosts.map(({ data, id }) => (
           <Card
             href={`/posts/${id}-${slugifyStr(data.Title)}`}
+            tags={data.Tags.map((tag: { Label: string }) => tag.Label)}
             frontmatter={{
               author: "x",
-              tags: data.Tags.map(tag => tag.Label),
               title: data.Title,
               pubDatetime: new Date(data.createdAt),
               modDatetime: new Date(data.updatedAt),

--- a/src/lib/strapi-loader.ts
+++ b/src/lib/strapi-loader.ts
@@ -201,8 +201,6 @@ async function fetchFromStrapi(
 
   console.log('Fetching URL:', url.toString());
 
-  console.log(url, params);
-
   try {
     const response = await fetch(url.href);
     if (!response.ok) {

--- a/src/lib/strapi-loader.ts
+++ b/src/lib/strapi-loader.ts
@@ -14,9 +14,9 @@ const SYNC_INTERVAL = 60 * 1000; // 1 minute in milliseconds
  * @param filter The filter to apply to the content &filters[store][id][$eq]=${STRAPI_STORE_ID}
  * @returns An Astro loader for the specified content type
  */
-export function strapiLoader({ contentType, filter }: { contentType: string, filter?: string }): Loader {
+export function strapiLoader({ contentType, filter, populate = 'SEO.socialImage' }: { contentType: string, filter?: string, populate?: string }): Loader {
   return {
-    name: "strapi-posts",
+    name: `strapi-${contentType}`,
 
     load: async function (this: Loader, { store, meta, logger }) {
       const lastSynced = meta.get("lastSynced");
@@ -43,7 +43,10 @@ export function strapiLoader({ contentType, filter }: { contentType: string, fil
           [filterKey, filterValue] = filter.split('=');
         }
 
-        const data = await fetchFromStrapi(`/api/${contentType}s?`, { [filterKey]: filterValue, populate: '*' });
+        const data = await fetchFromStrapi(`/api/${contentType}s?`, {
+          [filterKey]: filterValue,
+          populate,
+        });
         let posts = data?.data;
 
         if (!posts || !Array.isArray(posts)) {
@@ -175,10 +178,30 @@ async function fetchFromStrapi(
   const url = new URL(path, baseUrl || STRAPI_BASE_URL);
 
   if (params) {
+    // Handle populate parameters
+    if (params.populate) {
+      const populateFields = params.populate.split(',');
+      populateFields.forEach((field, index) => {
+        if (field.includes('.')) {
+          const [parent, child] = field.split('.');
+          url.searchParams.append('populate', parent);
+          url.searchParams.append(`populate[${index + 1}]`, `${parent}.${child}`);
+        } else {
+          url.searchParams.append('populate', field);
+        }
+      });
+      delete params.populate;
+    }
+
+    // Handle remaining parameters (including filters)
     Object.entries(params).forEach(([key, value]) => {
       url.searchParams.set(key, value);
     });
   }
+
+  console.log('Fetching URL:', url.toString());
+
+  console.log(url, params);
 
   try {
     const response = await fetch(url.href);

--- a/src/lib/strapi-loader.ts
+++ b/src/lib/strapi-loader.ts
@@ -44,11 +44,14 @@ export function strapiLoader({ contentType, filter }: { contentType: string, fil
         }
 
         const data = await fetchFromStrapi(`/api/${contentType}s?`, { [filterKey]: filterValue, populate: '*' });
-        const posts = data?.data;
+        let posts = data?.data;
 
         if (!posts || !Array.isArray(posts)) {
           throw new Error("Invalid data received from Strapi");
         }
+
+        // Sort posts by creation date in descending order
+        posts = posts.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
         // Get the schema
         const schemaOrFn = this.schema;

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
-import type { Page, Store } from "@interfaces/index";
+import type { Store } from "@interfaces/index";
+import HeroImage from "@components/HeroImage.astro";
 import {
   BlocksRenderer,
   type BlocksContent,
@@ -12,13 +13,13 @@ import Breadcrumbs from "@components/Breadcrumbs.astro";
 import Hr from "@components/Hr.astro";
 
 export interface Props {
-  page: CollectionEntry<"page">;
+  page: CollectionEntry<"pages">;
 }
 
 export async function getStaticPaths() {
   const pages = await getCollection("pages");
 
-  return pages.map((page: { data: CollectionEntry<"page"> }) => ({
+  return pages.map((page: CollectionEntry<"pages">) => ({
     params: { slug: page.data.slug },
     props: { page: page.data },
   }));
@@ -28,14 +29,20 @@ const stores = await getCollection("stores");
 const store = stores?.[0]?.data as unknown as Store;
 
 const { page } = Astro.props;
+console.log({ x: page });
+// const { SEO } = page.data;
 ---
 
 <Layout>
-  <Header store={store} activeNav={page.slug} />
-
+  <Header store={store} activeNav={page?.slug} />
   <Breadcrumbs />
   <main id="main-content">
     <section id="about" class="mb-10 max-w-3xl prose-img:border-0">
+      {
+        page?.SEO?.socialImage && (
+          <HeroImage image={page?.SEO?.socialImage} title={page?.Title} />
+        )
+      }
       <h1 class="text-2xl tracking-wider sm:text-3xl">{page.Title}</h1>
     </section>
 
@@ -45,4 +52,4 @@ const { page } = Astro.props;
     <Hr />
   </main>
 </Layout>
-<Footer />
+<Footer activeNav={page?.slug} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,14 +27,14 @@ const pages = await getCollection("pages");
 
 const homePage = pages.find(
   (page: { data: Page }) => page.data.slug === "home"
-) as unknown as { data: Page };
+) as { data: Page };
 
 const links = store?.URLS || [];
 
 // const products = store?.products?.data || [];
 ---
 
-<Layout>
+<Layout title={`Home | ${SITE.title}`}>
   <Header store={store} />
   <main id="main-content">
     <section id="hero">
@@ -122,33 +122,6 @@ const links = store?.URLS || [];
       <Hr />
 
       {
-        pages.length > 0 && (
-          <>
-            <section id="featured">
-              <h2>Pages</h2>
-              <ul>
-                {pages.map(page => (
-                  <Card
-                    href={`/${page.data.slug}/`}
-                    frontmatter={{
-                      author: "x",
-                      tags: ["x"],
-                      title: page.data.Title,
-                      pubDatetime: new Date(page.data.createdAt),
-                      modDatetime: new Date(page.data.updatedAt),
-                      description: page.data.SEO?.metaDescription || "",
-                    }}
-                    secHeading={false}
-                  />
-                ))}
-              </ul>
-            </section>
-            {posts.length > 0 && <Hr />}
-          </>
-        )
-      }
-
-      {
         posts.length > 0 && (
           <section id="recent-posts">
             <h2>Recent Posts</h2>
@@ -160,11 +133,12 @@ const links = store?.URLS || [];
                       href={`/posts/${id}-${slugifyStr(data.Title)}`}
                       frontmatter={{
                         author: "x",
-                        tags: data.Tags.map(tag => tag.Label),
+                        tags: data.Tags?.map(tag => tag.Label),
                         title: data.Title,
                         pubDatetime: new Date(data.createdAt),
                         modDatetime: new Date(data.updatedAt),
                         description: data.SEO?.metaDescription || "",
+                        SEO: { ...data.SEO },
                       }}
                       secHeading={false}
                     />
@@ -188,18 +162,25 @@ const links = store?.URLS || [];
       </div>
 
       <section class="mb-10 pt-10">
-        <p>
-          <LinkButton
-            className="underline decoration-dashed underline-offset-4 hover:text-skin-accent"
-            href="http://github.com/calimania/markketplace-astro"
-          >
-            Built with Markketplace-astro -
-          </LinkButton>
-          a minimal, responsive, accessible and SEO-friendly Astro blog theme, compatible
-          with Markketplace/Strapi. This theme follows best practices and provides
-          accessibility out of the box. Light and dark mode are supported by default.
-          Moreover, additional color schemes can also be configured.
-        </p>
+        {
+          !store?.Description && (
+            <>
+              <p>
+                <LinkButton
+                  className="underline decoration-dashed underline-offset-4 hover:text-skin-accent"
+                  href="http://github.com/calimania/markketplace-astro"
+                >
+                  Built with Markketplace-astro -
+                </LinkButton>
+                a minimal, responsive, accessible and SEO-friendly Astro blog
+                theme, compatible with Markketplace/Strapi. This theme follows
+                best practices and provides accessibility out of the box. Light
+                and dark mode are supported by default. Moreover, additional
+                color schemes can also be configured.
+              </p>
+            </>
+          )
+        }
       </section>
       <Hr />
       <section>

--- a/src/pages/pages.astro
+++ b/src/pages/pages.astro
@@ -1,0 +1,43 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@layouts/Layout.astro";
+import Main from "@layouts/Main.astro";
+import Card from "@components/Card";
+import { slugifyStr } from "@utils/slugify";
+import { SITE } from "@config";
+import Footer from "@components/Footer.astro";
+import Header from "@components/Header.astro";
+import type Store from "@interfaces/Store";
+
+const stores = await getCollection("stores");
+const store = stores?.[0]?.data as Store;
+
+let pages = await getCollection("pages");
+pages = pages.sort(
+  (a, b) =>
+    new Date(b.data.createdAt).getTime() - new Date(a.data.createdAt).getTime()
+);
+---
+
+<Layout title={`Pages Index | ${SITE.title}`}>
+  <Header store={store} activeNav="pages" />
+  <Main pageTitle="Pages" pageDesc="A list of all pages.">
+    <ul>
+      {
+        pages.map(page => (
+          <Card
+            href={`/${slugifyStr(page.data.slug) || "#"}/`}
+            frontmatter={{
+              title: page.data.Title,
+              pubDatetime: new Date(page.data.createdAt),
+              modDatetime: new Date(page.data.updatedAt),
+              description: page.data.SEO?.metaDescription || "",
+              SEO: { ...page.data.SEO },
+            }}
+          />
+        ))
+      }
+    </ul>
+    <Footer activeNav="pages" />
+  </Main>
+</Layout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -6,6 +6,7 @@ import { slugifyStr } from "@utils/slugify";
 export async function GET() {
   const posts = await getCollection("posts");
   const pages = await getCollection("pages");
+  // const products =
 
   const items = [];
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -29,5 +29,5 @@ const searchList = posts.map(({ data, id }) => ({
   <Main pageTitle="Search" pageDesc="Search any article ...">
     <SearchBar client:load searchList={searchList} />
   </Main>
-  <Footer />
+  <Footer activeNav="search" />
 </Layout>

--- a/src/pages/tags/[tag]/[page].astro
+++ b/src/pages/tags/[tag]/[page].astro
@@ -8,22 +8,38 @@ import getPagination from "@utils/getPagination";
 
 export interface Props {
   post: CollectionEntry<"posts">;
-  tag: string;
+  tag?: string;
   tagName: string;
 }
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
-
   const tags = getUniqueTags(posts);
+
+  // Handle case with no tags
+  if (!tags.length) {
+    return [
+      {
+        params: { tag: "all", page: "1" },
+        props: { tag: "all", tagName: "All Posts", page: "1" },
+      },
+    ];
+  }
 
   return tags.flatMap(({ tag, tagName }) => {
     const tagPosts = getPostsByTag(posts, tag);
     const totalPages = getPageNumbers(tagPosts.length);
 
-    return totalPages.map(page => ({
-      params: { tag, page },
-      props: { tag, tagName },
+    return totalPages.map(pageNum => ({
+      params: {
+        tag: tag || "all",
+        page: String(pageNum),
+      },
+      props: {
+        tag,
+        tagName,
+        page: String(pageNum),
+      },
     }));
   });
 }
@@ -33,7 +49,7 @@ const { tag, tagName } = Astro.props;
 
 const posts = await getCollection("posts");
 
-const postsByTag = getPostsByTag(posts, tag);
+const postsByTag = getPostsByTag(posts, tag || "all");
 
 const pagination = getPagination({
   posts: postsByTag,
@@ -41,4 +57,4 @@ const pagination = getPagination({
 });
 ---
 
-<TagPosts {...pagination} {tag} {tagName} />
+<TagPosts {...pagination} tag={tag || "all"} tagName={tagName || "all"} />

--- a/src/pages/tags/[tag]/index.astro
+++ b/src/pages/tags/[tag]/index.astro
@@ -7,15 +7,22 @@ import getUniqueTags from "@utils/getUniqueTags";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
-
   const tags = getUniqueTags(posts);
 
-  return tags.map(({ tag, tagName }) => {
-    return {
-      params: { tag },
-      props: { tag, tagName, posts },
-    };
-  });
+  // Add default "all" tag
+  const allTags = [
+    { tag: "all", tagName: "All Posts" },
+    ...tags.filter(tag => tag.tag && tag.tag.length > 0), // Filter out empty tags
+  ];
+
+  return allTags.map(({ tag, tagName }) => ({
+    params: { tag: tag || "all" }, // Ensure tag is never empty
+    props: {
+      tag: tag || "all",
+      tagName: tagName || "All Posts",
+      posts: tag === "all" ? posts : getPostsByTag(posts, tag),
+    },
+  }));
 }
 
 const { tag, tagName, posts } = Astro.props;

--- a/src/utils/getPostsByTag.ts
+++ b/src/utils/getPostsByTag.ts
@@ -3,7 +3,7 @@ import { slugifyStr } from "./slugify";
 
 const getPostsByTag = (posts: CollectionEntry<"posts">[], tag: string) =>
   posts.filter(post => {
-    const tags = post.data.Tags.map(tag => slugifyStr(tag.Label));
+    const tags = post.data.Tags.map((post_tag: { Label: string }) => slugifyStr(post_tag.Label));
     return tags.includes(tag);
   })
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -18,7 +18,19 @@ module.exports = {
       sm: "640px",
     },
 
+
+
     extend: {
+      colors: {
+        accent: {
+          100: '#e6f7ff',
+          300: '#91d5ff',
+          400: '#69c0ff',
+          500: '#40a9ff',
+          700: '#096dd9',
+          900: '#003a8c',
+        },
+      },
       textColor: {
         skin: {
           base: withOpacity("--color-text-base"),


### PR DESCRIPTION
This pull request includes changes to the configuration settings and the data fetching logic from Strapi. The most important changes include updating the number of posts per page and adding sorting functionality to the fetched posts.

Configuration updates:

* [`src/config.ts`](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L17-R17): Changed the `postPerPage` value from 3 to 8 to display more posts per page.

Data fetching improvements:

* [`src/lib/strapi-loader.ts`](diffhunk://#diff-1d4ba582f509754d1bfcd8272129bdcb679107f656c6c67d37220be08d839f6eL47-R55): Modified the `posts` variable to be mutable and added sorting functionality to order posts by creation date in descending order.